### PR TITLE
feat: Set default Jira issue fields to summary, description, comment

### DIFF
--- a/src/jira-client.ts
+++ b/src/jira-client.ts
@@ -22,10 +22,11 @@ export class JiraClient {
 
   async getTicket(ticketId: string, expand?: string[], fields?: string[]): Promise<Issue> {
     try {
+      const effectiveFields = fields && fields.length > 0 ? fields : ["summary", "description", "comment"];
       const params = {
         issueIdOrKey: ticketId,
         expand: expand?.join(','),
-        fields
+        fields: effectiveFields
       };
       return await this.client.issues.getIssue(params);
     } catch (error: unknown) {

--- a/src/simpleTest.ts
+++ b/src/simpleTest.ts
@@ -10,10 +10,13 @@ async function runTest() {
 
   try {
     const jiraClient = new JiraClient();
-    const ticket = await jiraClient.getTicket(ticketId, ['summary', 'description']);
+    // Call getTicket without the explicit fields array
+    const ticket = await jiraClient.getTicket(ticketId); // No expand, no fields
 
     console.log(`Summary: ${ticket.fields.summary}`);
     console.log(`Description: ${ticket.fields.description}`);
+    // Add console.log for comments
+    console.log(`Comments: ${JSON.stringify(ticket.fields.comment, null, 2)}`);
 
   } catch (error: any) {
     console.error(`Error fetching ticket ${ticketId}: ${error.message}`);


### PR DESCRIPTION
Updates the JiraClient's getTicket method to default to fetching "summary", "description", and "comment" fields when no specific fields are requested by the caller.

The associated simpleTest.ts script was updated to reflect this change for testing purposes. However, due to environmental constraints (missing 'bun' runtime and tsc/jira.js module resolution issues), automated testing could not be completed. You have acknowledged this and will perform testing manually.