### PR TITLE
Fix: Resolve build failures due to missing TypeScript types for node and vitest

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
     "verbatimModuleSyntax": true, // Recommended for ESM
 
     // Best practices
+    "types": ["node", "vitest"],
     "strict": true,
     "skipLibCheck": true,
     "noFallthroughCasesInSwitch": true,


### PR DESCRIPTION
This PR adds the missing explicit type declarations for `node` and `vitest` in `tsconfig.json`. This was causing `npm run build` to fail when running the tests, as globals like `process` and `console` were missing during the type compilation.

Steps completed:
- Reinstalled dependencies via `npm install`
- Verified tests broken by compilation errors `Cannot find name 'process'` and `Cannot find name 'console'`.
- Updated `tsconfig.json` to include `"types": ["node", "vitest"]`.
- Validated via `npm run build` and `npm test` that all tests pass.

---
*PR created automatically by Jules for task [16604823724892989020](https://jules.google.com/task/16604823724892989020) started by @scho-to*